### PR TITLE
0.1.3

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -30,7 +30,7 @@ export function willPaginate (client: any, method: string, formatter: Function, 
           });
         }, (iterator)  => {
           return !!iterator.total && (iterator.results.length >= iterator.total);
-        }, (iterator) => { }, {
+        }, (iterator) => {}, {
         results: [],
         total: null,
         offset: offset,


### PR DESCRIPTION
feat(playlist/tracks): add polling to avoid making "too many requests issue when there is a lot of playlists

GraphQL calls resolvers in parallel, so the following request : 

```
{
    me {
      playlists {
        tracks {
          track {
            id
          }
        }
      }
    }
  }
```

will trigger 155 HTTP requests at once when current user have 155 playlists ...

So, the playlist.tracks resolver use a "lock-based" polling system to avoid "Too many requests" issue